### PR TITLE
Rotation Suffix Time Format [https://github.com/DeRuina/timberjack/issues/5]

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ func main() {
 		LocalTime:  true,           // default: false (use UTC)
 		RotationInterval: time.Hour * 24, // Rotate daily if no other rotation met
 		RotateAtMinutes: []int{0, 15, 30, 45}, // Also rotate at HH:00, HH:15, HH:30, HH:45
+    BackupTimeFormat: "2006-01-02-15-04-05" // Rotated files will have format <logfilename>-2006-01-02-15-04-05-<rotationCriterion>-timberjack.log
 	}
 	log.SetOutput(logger)
 	defer logger.Close() // Ensure logger is closed on application exit to stop goroutines
@@ -88,7 +89,7 @@ type Logger struct {
     Compress         bool          // Compress rotated logs (gzip)
     RotationInterval time.Duration // Rotate after this duration (if > 0)
     RotateAtMinutes []int          // Specific minutes within an hour (0-59) to trigger a rotation.
-    BackupTimeFormat string        // REQUIRED to generate filenames for rotated files
+    BackupTimeFormat string        // OPTIONAL with default value : 2006-01-02T15-04-05.000
 }
 ```
 
@@ -117,8 +118,8 @@ For example:
 ## ⚠️ Rotation Notes & Warnings
 
 * **`BackupTimeFormat` Values must be valid and should not change after initialization**  
-  The `BackupTimeFormat` value **cannot be empty** and must follow the timestamp layout rules
-  specified here: https://pkg.go.dev/time#pkg-constants. Using invalid values will result in errors.
+  The `BackupTimeFormat` value **must be valid** and must follow the timestamp layout rules
+  specified here: https://pkg.go.dev/time#pkg-constants. `BackupTimeFormat` supports more formats but it's recommended to use standard formats. If **invalid** value is configured, then the default time format is used : `2006-01-02T15-04-05.000`. 
 
 * **Silent Ignoring of Invalid `RotateAtMinutes` Values**  
   Values outside the valid range (`0–59`) or duplicates in `RotateAtMinutes` are silently ignored. No warnings or errors will be logged. This allows the program to continue safely, but the rotation behavior may not match your expectations if values are invalid.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ type Logger struct {
     Compress         bool          // Compress rotated logs (gzip)
     RotationInterval time.Duration // Rotate after this duration (if > 0)
     RotateAtMinutes []int          // Specific minutes within an hour (0-59) to trigger a rotation.
+    BackupTimeFormat string        // REQUIRED to generate filenames for rotated files
 }
 ```
 
@@ -114,6 +115,10 @@ For example:
 ```
 
 ## ⚠️ Rotation Notes & Warnings
+
+* **`BackupTimeFormat` Values must be valid and should not change after initialization**  
+  The `BackupTimeFormat` value **cannot be empty** and must follow the timestamp layout rules
+  specified here: https://pkg.go.dev/time#pkg-constants. Using invalid values will result in errors.
 
 * **Silent Ignoring of Invalid `RotateAtMinutes` Values**  
   Values outside the valid range (`0–59`) or duplicates in `RotateAtMinutes` are silently ignored. No warnings or errors will be logged. This allows the program to continue safely, but the rotation behavior may not match your expectations if values are invalid.

--- a/timberjack.go
+++ b/timberjack.go
@@ -538,8 +538,10 @@ func isValidSuffixTimeFormat(layout string) bool {
 	return parsedT.Equal(now) && err == nil
 }
 
-// countDigitsAfterDot counts the number of digits after a `.`.
-// It won't care about prefix of `.` and only counts first set of digits after `.`.
+// countDigitsAfterDot returns the number of consecutive digit characters
+// immediately following the first '.' in the input.
+// It skips all characters before the '.' and stops counting at the first non-digit
+// character after the '.'.
 
 // Example: `prefix.0012304123suffix` would return 10
 // Example: `prefix.0012304_middle_123_suffix` would return 7

--- a/timberjack.go
+++ b/timberjack.go
@@ -515,6 +515,7 @@ func (l *Logger) openNew(reasonForBackup string) error {
 				// backup format is empty or invalid.
 				// use backupformat constant
 				l.BackupTimeFormat = backupTimeFormat
+				fmt.Fprintf(os.Stderr, "timberjack: invalid BackupTimeFormat: %v — falling back to default format: %s\n", validationErr, backupTimeFormat)
 			}
 			// mark the backup format as validated if there was no error.
 			// this would prevent validation checks in every rotation
@@ -834,7 +835,12 @@ func (l *Logger) timeFromName(filename, prefix, ext string) (time.Time, error) {
 	if l.LocalTime {
 		currentLoc = time.Local
 	}
-	return time.ParseInLocation(backupTimeFormat, timestampPart, currentLoc)
+
+	layout := l.BackupTimeFormat
+	if layout == "" {
+		layout = backupTimeFormat
+	}
+	return time.ParseInLocation(layout, timestampPart, currentLoc)
 }
 
 // max returns the maximum size in bytes of log files before rolling.

--- a/timberjack.go
+++ b/timberjack.go
@@ -860,37 +860,6 @@ func (l *Logger) prefixAndExt() (prefix, ext string) {
 	return prefix, ext
 }
 
-// isValidTimeFormat determines the validity of the `layout` as a format for time.Time.
-// Counts the number of digits after `.` in the layout format and compares till that precision.
-//
-// Internally, it generates a time.Time value with required precision.
-// This generated time.Time value is used to format time in the given `layout`.
-// Using the formatted string, we construct a time.Time value to compare with original time.Time
-func isValidTimeFormat(layout string) error {
-	if len(layout) == 0 {
-		return errors.New("timeformat cannot be empty")
-	}
-	// 2025-05-22 23:41:59.987654321 +0000 UTC
-	now := time.Date(2025, 05, 22, 23, 41, 59, 987_654_321, time.UTC)
-
-	layoutPrecision := countDigitsAfterDot(layout)
-
-	now, err := truncateFractional(now, layoutPrecision)
-
-	if err != nil {
-		return err
-	}
-	formatted := now.Format(layout)
-	parsedT, err := time.Parse(layout, formatted)
-	if err != nil {
-		return err
-	}
-	if !parsedT.Equal(now) {
-		return errors.New("timeformat is invalid")
-	}
-	return nil
-}
-
 // countDigitsAfterDot returns the number of consecutive digit characters
 // immediately following the first '.' in the input.
 // It skips all characters before the '.' and stops counting at the first non-digit

--- a/timberjack_test.go
+++ b/timberjack_test.go
@@ -80,9 +80,8 @@ func TestWriteTooLong(t *testing.T) {
 	dir := makeTempDir("TestWriteTooLong", t)
 	defer os.RemoveAll(dir)
 	l := &Logger{
-		Filename:         logFile(dir),
-		MaxSize:          5,
-		BackupTimeFormat: backupTimeFormat,
+		Filename: logFile(dir),
+		MaxSize:  5,
 	}
 	defer l.Close()
 	b := []byte("booooooooooooooo!")
@@ -102,8 +101,7 @@ func TestMakeLogDir(t *testing.T) {
 	defer os.RemoveAll(dir)
 	filename := logFile(dir)
 	l := &Logger{
-		Filename:         filename,
-		BackupTimeFormat: backupTimeFormat,
+		Filename: filename,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -119,9 +117,7 @@ func TestDefaultFilename(t *testing.T) {
 	dir := os.TempDir()
 	filename := filepath.Join(dir, filepath.Base(os.Args[0])+"-timberjack.log")
 	defer os.Remove(filename)
-	l := &Logger{
-		BackupTimeFormat: backupTimeFormat,
-	}
+	l := &Logger{}
 	defer l.Close()
 	b := []byte("boo!")
 	n, err := l.Write(b)
@@ -140,9 +136,8 @@ func TestAutoRotate(t *testing.T) {
 
 	filename := logFile(dir)
 	l := &Logger{
-		Filename:         filename,
-		MaxSize:          10,
-		BackupTimeFormat: backupTimeFormat,
+		Filename: filename,
+		MaxSize:  10,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -178,9 +173,8 @@ func TestFirstWriteRotate(t *testing.T) {
 
 	filename := logFile(dir)
 	l := &Logger{
-		Filename:         filename,
-		MaxSize:          10,
-		BackupTimeFormat: backupTimeFormat,
+		Filename: filename,
+		MaxSize:  10,
 	}
 	defer l.Close()
 
@@ -210,10 +204,9 @@ func TestMaxBackups(t *testing.T) {
 
 	filename := logFile(dir)
 	l := &Logger{
-		Filename:         filename,
-		MaxSize:          10,
-		MaxBackups:       1,
-		BackupTimeFormat: backupTimeFormat,
+		Filename:   filename,
+		MaxSize:    10,
+		MaxBackups: 1,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -363,10 +356,9 @@ func TestCleanupExistingBackups(t *testing.T) {
 	isNil(err, t)
 
 	l := &Logger{
-		Filename:         filename,
-		MaxSize:          10,
-		MaxBackups:       1,
-		BackupTimeFormat: backupTimeFormat,
+		Filename:   filename,
+		MaxSize:    10,
+		MaxBackups: 1,
 	}
 	defer l.Close()
 
@@ -394,10 +386,9 @@ func TestMaxAge(t *testing.T) {
 
 	filename := logFile(dir)
 	l := &Logger{
-		Filename:         filename,
-		MaxSize:          10,
-		MaxAge:           1,
-		BackupTimeFormat: backupTimeFormat,
+		Filename: filename,
+		MaxSize:  10,
+		MaxAge:   1,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -494,10 +485,7 @@ func TestOldLogFiles(t *testing.T) {
 }
 
 func TestTimeFromName(t *testing.T) {
-	l := &Logger{
-		Filename:         "/var/log/myfoo/foo.log",
-		BackupTimeFormat: backupTimeFormat,
-	}
+	l := &Logger{Filename: "/var/log/myfoo/foo.log"}
 	prefix, ext := l.prefixAndExt()
 
 	tests := []struct {
@@ -526,10 +514,9 @@ func TestLocalTime(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	l := &Logger{
-		Filename:         logFile(dir),
-		MaxSize:          10,
-		LocalTime:        true,
-		BackupTimeFormat: backupTimeFormat,
+		Filename:  logFile(dir),
+		MaxSize:   10,
+		LocalTime: true,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -554,10 +541,9 @@ func TestRotate(t *testing.T) {
 	filename := logFile(dir)
 
 	l := &Logger{
-		Filename:         filename,
-		MaxBackups:       1,
-		MaxSize:          100, // megabytes
-		BackupTimeFormat: backupTimeFormat,
+		Filename:   filename,
+		MaxBackups: 1,
+		MaxSize:    100, // megabytes
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -613,10 +599,9 @@ func TestCompressOnRotate(t *testing.T) {
 
 	filename := logFile(dir)
 	l := &Logger{
-		Compress:         true,
-		Filename:         filename,
-		MaxSize:          10,
-		BackupTimeFormat: backupTimeFormat,
+		Compress: true,
+		Filename: filename,
+		MaxSize:  10,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -663,10 +648,9 @@ func TestCompressOnResume(t *testing.T) {
 
 	filename := logFile(dir)
 	l := &Logger{
-		Compress:         true,
-		Filename:         filename,
-		MaxSize:          10,
-		BackupTimeFormat: backupTimeFormat,
+		Compress: true,
+		Filename: filename,
+		MaxSize:  10,
 	}
 	defer l.Close()
 
@@ -715,9 +699,7 @@ func TestJson(t *testing.T) {
 	"compress": true
 }`[1:])
 
-	l := Logger{
-		BackupTimeFormat: backupTimeFormat,
-	}
+	l := Logger{}
 	err := json.Unmarshal(data, &l)
 	isNil(err, t)
 	equals("foo", l.Filename, t)
@@ -793,7 +775,6 @@ func TestTimeBasedRotation(t *testing.T) {
 		Filename:         filename,
 		MaxSize:          10000,           // disable size rotation
 		RotationInterval: time.Second * 1, // short interval
-		BackupTimeFormat: backupTimeFormat,
 	}
 	defer l.Close()
 
@@ -834,120 +815,6 @@ func TestTimeBasedRotation(t *testing.T) {
 	}
 }
 
-func TestSuffixTimeFormat(t *testing.T) {
-	tmp := t.TempDir()
-	logFile := filepath.Join(tmp, "invalid.log")
-
-	logger := &Logger{
-		Filename:         logFile,
-		BackupTimeFormat: backupTimeFormat,
-	}
-	// parses correctly with err == nil, but parsed time.Time won't match the supplied time.Time
-
-	invalidFormat := "2006-15-05 23:20:53"
-	logger.BackupTimeFormat = invalidFormat
-	err := logger.ValidateBackupTimeFormat()
-	if err == nil {
-		t.Fatalf("invalid timestamp layout determined as valid")
-	}
-
-	validFormat := `2006-01-02-15-05-44.000`
-	logger.BackupTimeFormat = validFormat
-	err = logger.ValidateBackupTimeFormat()
-	if err != nil {
-		t.Errorf("valid timestamp layout determined as invalid")
-	}
-
-	validFormat2 := `2006-01-02-15-05-44.00000` // precision upto 5 digits after .
-	logger.BackupTimeFormat = validFormat2
-	err = logger.ValidateBackupTimeFormat()
-	if err != nil {
-		t.Errorf("valid timestamp2 layout determined as invalid")
-	}
-
-	validFormat3 := `2006-01-02-15-05-44.0000000` // precision upto 7 digits after .
-	logger.BackupTimeFormat = validFormat3
-	err = logger.ValidateBackupTimeFormat()
-	if err != nil {
-		t.Errorf("valid timestamp2 layout determined as invalid")
-	}
-
-	validFormat4 := `20060102-15-05` // precision upto 7 digits after .
-	logger.BackupTimeFormat = validFormat4
-	err = logger.ValidateBackupTimeFormat()
-	if err == nil {
-		t.Errorf("timestamp4 is invalid but determined as valid")
-	}
-}
-
-func TestCountDigitsAfterDot(t *testing.T) {
-	tests := []struct {
-		layout   string
-		expected int
-	}{
-		{"2006-01-02 15:04:05", 0},           // no dot
-		{"2006-01-02 15:04:05.000", 3},       // exactly 3 digits
-		{"2006-01-02 15:04:05.000000", 6},    // 6 digits
-		{"2006-01-02 15:04:05.999999999", 9}, // 9 digits
-		{"2006-01-02 15:04:05.12345abc", 5},  // digits then letters
-		{"2006-01-02 15:04:05.", 0},          // dot but no digits
-		{".1234", 4},                         // string starts with dot + digits
-		{"prefix.987suffix", 3},              // digits then letters after dot
-		{"no_digits_after_dot.", 0},          // dot at end
-		{"no.dot.in.string", 0},              // dot but not fractional part
-	}
-
-	for _, test := range tests {
-		got := countDigitsAfterDot(test.layout)
-		if got != test.expected {
-			t.Errorf("countDigitsAfterDot(%q) = %d; want %d", test.layout, got, test.expected)
-		}
-	}
-}
-
-func TestTruncateFractional(t *testing.T) {
-	baseTime := time.Date(2025, 5, 23, 14, 30, 45, 987654321, time.UTC)
-
-	tests := []struct {
-		n         int
-		wantNanos int
-		wantErr   bool
-	}{
-		{n: 0, wantNanos: 0, wantErr: false},         // truncate to seconds
-		{n: 1, wantNanos: 900000000, wantErr: false}, // 1 digit fractional (100ms)
-		{n: 3, wantNanos: 987000000, wantErr: false}, // milliseconds
-		{n: 5, wantNanos: 987650000, wantErr: false}, // upto 5 digits
-		{n: 6, wantNanos: 987654000, wantErr: false}, // microseconds
-		{n: 7, wantNanos: 987654300, wantErr: false}, // upto 7 digits
-		{n: 9, wantNanos: 987654321, wantErr: false}, // nanoseconds, no truncation
-		{n: -1, wantNanos: 0, wantErr: true},         // invalid low
-		{n: 10, wantNanos: 0, wantErr: true},         // invalid high
-	}
-
-	for _, tt := range tests {
-		got, err := truncateFractional(baseTime, tt.n)
-
-		if (err != nil) != tt.wantErr {
-			t.Errorf("truncateFractional(_, %d) error = %v, wantErr %v", tt.n, err, tt.wantErr)
-			continue
-		}
-		if err != nil {
-			continue // don't check time if error expected
-		}
-
-		if got.Nanosecond() != tt.wantNanos {
-			t.Errorf("truncateFractional(_, %d) Nanosecond = %d; want %d", tt.n, got.Nanosecond(), tt.wantNanos)
-		}
-
-		// Verify that other time components are unchanged
-		if got.Year() != baseTime.Year() || got.Month() != baseTime.Month() ||
-			got.Day() != baseTime.Day() || got.Hour() != baseTime.Hour() ||
-			got.Minute() != baseTime.Minute() || got.Second() != baseTime.Second() {
-			t.Errorf("truncateFractional(_, %d) modified time components", tt.n)
-		}
-	}
-}
-
 // TestSizeBasedRotation specifically tests rotation when MaxSize is exceeded.
 func TestSizeBasedRotation(t *testing.T) {
 	currentTime = fakeTime // Ensure our mock time is used
@@ -958,11 +825,10 @@ func TestSizeBasedRotation(t *testing.T) {
 
 	filename := logFile(dir) // e.g., /tmp/.../foobar.log
 	l := &Logger{
-		Filename:         filename,
-		MaxSize:          10, // Max size of 10 bytes
-		MaxBackups:       1,
-		LocalTime:        false, // To match backupFileWithReason which uses UTC
-		BackupTimeFormat: backupTimeFormat,
+		Filename:   filename,
+		MaxSize:    10, // Max size of 10 bytes
+		MaxBackups: 1,
+		LocalTime:  false, // To match backupFileWithReason which uses UTC
 	}
 	defer l.Close()
 
@@ -1019,11 +885,10 @@ func TestRotateAtMinutes(t *testing.T) {
 	filename := logFile(dir)
 
 	l := &Logger{
-		Filename:         filename,
-		RotateAtMinutes:  marks,
-		MaxSize:          1000,  // disable size-based rotation
-		LocalTime:        false, // use UTC for backup timestamps
-		BackupTimeFormat: backupTimeFormat,
+		Filename:        filename,
+		RotateAtMinutes: marks,
+		MaxSize:         1000,  // disable size-based rotation
+		LocalTime:       false, // use UTC for backup timestamps
 	}
 	defer l.Close() // stop scheduling goroutine
 
@@ -1123,9 +988,8 @@ func TestOpenExistingOrNew_Fallback(t *testing.T) {
 	path := filepath.Join(tmpDir, "readonly.log")
 
 	logger := &Logger{
-		Filename:         path,
-		MaxSize:          1,
-		BackupTimeFormat: backupTimeFormat,
+		Filename: path,
+		MaxSize:  1,
 	}
 
 	// Create a file with 0 perms so append will fail
@@ -1148,11 +1012,10 @@ func TestMillRunOnce_OldFilesRemoved(t *testing.T) {
 	_ = os.WriteFile(oldLog, []byte("data"), 0644)
 
 	logger := &Logger{
-		Filename:         filepath.Join(dir, "test.log"),
-		MaxAge:           1,
-		Compress:         false,
-		MaxBackups:       0,
-		BackupTimeFormat: backupTimeFormat,
+		Filename:   filepath.Join(dir, "test.log"),
+		MaxAge:     1,
+		Compress:   false,
+		MaxBackups: 0,
 	}
 	currentTime = func() time.Time {
 		return time.Now().AddDate(0, 0, 10)
@@ -1168,10 +1031,7 @@ func TestMillRunOnce_OldFilesRemoved(t *testing.T) {
 }
 
 func TestTimeFromName_InvalidFormat(t *testing.T) {
-	logger := &Logger{
-		Filename:         "foo.log",
-		BackupTimeFormat: backupTimeFormat,
-	}
+	logger := &Logger{Filename: "foo.log"}
 	prefix, ext := logger.prefixAndExt()
 
 	// Case 1: mismatched prefix
@@ -1213,7 +1073,6 @@ func TestBackupName(t *testing.T) {
 func TestShouldTimeRotate_WhenZero(t *testing.T) {
 	l := &Logger{
 		RotationInterval: time.Second,
-		BackupTimeFormat: backupTimeFormat,
 	}
 
 	currentTime = func() time.Time {
@@ -1232,7 +1091,6 @@ func TestShouldTimeRotate_WhenElapsed(t *testing.T) {
 	l := &Logger{
 		RotationInterval: time.Minute,
 		lastRotationTime: time.Date(2025, 1, 1, 11, 58, 0, 0, time.UTC),
-		BackupTimeFormat: backupTimeFormat,
 	}
 	if !l.shouldTimeRotate() {
 		t.Error("expected rotation due to elapsed time")
@@ -1240,9 +1098,7 @@ func TestShouldTimeRotate_WhenElapsed(t *testing.T) {
 }
 
 func TestRunScheduledRotations_NoMarks(t *testing.T) {
-	l := &Logger{
-		BackupTimeFormat: backupTimeFormat,
-	}
+	l := &Logger{}
 	l.scheduledRotationWg.Add(1)
 
 	// processedRotateAtMinutes is empty — triggers early return
@@ -1265,8 +1121,7 @@ func TestRunScheduledRotations_NoMarks(t *testing.T) {
 func TestRotate_OpenNewFails(t *testing.T) {
 	badPath := "/bad/path/logfile.log"
 	l := &Logger{
-		Filename:         badPath,
-		BackupTimeFormat: backupTimeFormat,
+		Filename: badPath,
 	}
 	// force an invalid path to trigger openNew failure
 	err := l.rotate("manual")
@@ -1283,7 +1138,6 @@ func TestRotate_TriggersTimeReason(t *testing.T) {
 		Filename:         filepath.Join(t.TempDir(), "time-reason.log"),
 		RotationInterval: time.Minute,
 		lastRotationTime: time.Date(2024, 5, 1, 11, 58, 0, 0, time.UTC),
-		BackupTimeFormat: backupTimeFormat,
 	}
 	defer l.Close()
 
@@ -1311,7 +1165,6 @@ func TestRunScheduledRotations_NoFutureTime(t *testing.T) {
 		RotateAtMinutes:         []int{0},
 		scheduledRotationWg:     sync.WaitGroup{},
 		scheduledRotationQuitCh: make(chan struct{}),
-		BackupTimeFormat:        backupTimeFormat,
 	}
 	logger.processedRotateAtMinutes = []int{0}
 
@@ -1328,8 +1181,7 @@ func TestRunScheduledRotations_NoFutureTime(t *testing.T) {
 
 func TestEnsureScheduledRotationLoopRunning_InvalidMinutes(t *testing.T) {
 	l := &Logger{
-		RotateAtMinutes:  []int{61, -1, 999}, // invalid minutes
-		BackupTimeFormat: backupTimeFormat,
+		RotateAtMinutes: []int{61, -1, 999}, // invalid minutes
 	}
 	l.ensureScheduledRotationLoopRunning()
 
@@ -1377,10 +1229,7 @@ func TestOpenNew_RenameFails(t *testing.T) {
 	}
 	defer func() { osRename = originalRename }()
 
-	l := &Logger{
-		Filename:         file,
-		BackupTimeFormat: backupTimeFormat,
-	}
+	l := &Logger{Filename: file}
 	err := l.openNew("size")
 
 	if err == nil || !strings.Contains(err.Error(), "can't rename") {
@@ -1414,8 +1263,7 @@ func TestRotate_CloseFileFails(t *testing.T) {
 	_ = f.Close() // Close early to simulate Close() failure
 
 	l := &Logger{
-		file:             f,
-		BackupTimeFormat: backupTimeFormat,
+		file: f,
 	}
 
 	err = l.Rotate()
@@ -1425,10 +1273,7 @@ func TestRotate_CloseFileFails(t *testing.T) {
 }
 
 func TestOpenNew_StatUnexpectedError(t *testing.T) {
-	logger := &Logger{
-		Filename:         filepath.Join(t.TempDir(), "logfile.log"),
-		BackupTimeFormat: backupTimeFormat,
-	}
+	logger := &Logger{Filename: filepath.Join(t.TempDir(), "logfile.log")}
 
 	originalOsStat := osStat
 	osStat = func(name string) (os.FileInfo, error) {
@@ -1475,10 +1320,7 @@ func TestOpenExistingOrNew_StatFailure(t *testing.T) {
 		return nil, fmt.Errorf("mock stat failure")
 	}
 
-	logger := &Logger{
-		Filename:         "somefile.log",
-		BackupTimeFormat: backupTimeFormat,
-	}
+	logger := &Logger{Filename: "somefile.log"}
 	logger.millCh = make(chan bool, 1) // prevent nil panic
 	err := logger.openExistingOrNew(10)
 	if err == nil || !strings.Contains(err.Error(), "error getting log file info") {
@@ -1499,10 +1341,7 @@ func TestOpenNew_OpenFileFails(t *testing.T) {
 	// Attempt to use that file as a directory
 	badPath := filepath.Join(fileAsDir, "should_fail.log")
 
-	logger := &Logger{
-		Filename:         badPath,
-		BackupTimeFormat: backupTimeFormat,
-	}
+	logger := &Logger{Filename: badPath}
 	err = logger.openNew("size")
 
 	if err == nil || !strings.Contains(err.Error(), "can't make directories") {
@@ -1523,7 +1362,6 @@ func TestRunScheduledRotations_NoFutureSlot(t *testing.T) {
 		Filename:                "invalid.log",
 		RotateAtMinutes:         []int{0},
 		scheduledRotationQuitCh: make(chan struct{}),
-		BackupTimeFormat:        backupTimeFormat,
 	}
 	logger.processedRotateAtMinutes = []int{0}
 	logger.scheduledRotationWg.Add(1)
@@ -1536,10 +1374,7 @@ func TestRunScheduledRotations_NoFutureSlot(t *testing.T) {
 }
 
 func TestTimeFromName_MalformedFilename(t *testing.T) {
-	logger := &Logger{
-		Filename:         "foo.log",
-		BackupTimeFormat: backupTimeFormat,
-	}
+	logger := &Logger{Filename: "foo.log"}
 	prefix, ext := logger.prefixAndExt()
 
 	// Missing final hyphen separator, so no reason part
@@ -1561,9 +1396,8 @@ func TestWrite_OpenExistingFails(t *testing.T) {
 	}
 
 	logger := &Logger{
-		Filename:         filepath.Join(t.TempDir(), "badfile.log"),
-		MaxSize:          10,
-		BackupTimeFormat: backupTimeFormat,
+		Filename: filepath.Join(t.TempDir(), "badfile.log"),
+		MaxSize:  10,
 	}
 
 	// prevent nil panic
@@ -1600,7 +1434,6 @@ func TestWrite_IntervalRotateFails(t *testing.T) {
 		Filename:         logfile,
 		RotationInterval: time.Second,
 		lastRotationTime: time.Date(2025, 1, 1, 11, 59, 0, 0, time.UTC),
-		BackupTimeFormat: backupTimeFormat,
 	}
 	defer l.Close()
 
@@ -1634,9 +1467,8 @@ func TestWrite_SizeRotateFails(t *testing.T) {
 	}
 
 	l := &Logger{
-		Filename:         logfile,
-		MaxSize:          10, // force rotation at 10 bytes
-		BackupTimeFormat: backupTimeFormat,
+		Filename: logfile,
+		MaxSize:  10, // force rotation at 10 bytes
 	}
 	defer l.Close()
 
@@ -1820,8 +1652,7 @@ func TestCompressLogFile_RemoveFails(t *testing.T) {
 
 func TestEnsureScheduledRotationLoopRunning_Empty(t *testing.T) {
 	l := &Logger{
-		RotateAtMinutes:  nil, // empty case
-		BackupTimeFormat: backupTimeFormat,
+		RotateAtMinutes: nil, // empty case
 	}
 	l.ensureScheduledRotationLoopRunning()
 
@@ -1832,8 +1663,7 @@ func TestEnsureScheduledRotationLoopRunning_Empty(t *testing.T) {
 
 func TestEnsureScheduledRotationLoopRunning_InvalidMinutes_1(t *testing.T) {
 	l := &Logger{
-		RotateAtMinutes:  []int{-5, 60, 999, -1}, // all invalid
-		BackupTimeFormat: backupTimeFormat,
+		RotateAtMinutes: []int{-5, 60, 999, -1}, // all invalid
 	}
 	l.ensureScheduledRotationLoopRunning()
 
@@ -1860,7 +1690,6 @@ func TestRunScheduledRotations_NoFutureSlotFallback(t *testing.T) {
 		Filename:                "test-fallback.log",
 		RotateAtMinutes:         []int{0},
 		scheduledRotationQuitCh: make(chan struct{}),
-		BackupTimeFormat:        backupTimeFormat,
 	}
 	logger.processedRotateAtMinutes = []int{0}
 
@@ -1878,7 +1707,6 @@ func TestLoggerClose_AlreadyClosedChannel(t *testing.T) {
 	logger := &Logger{
 		Filename:                "test-double-close.log",
 		scheduledRotationQuitCh: make(chan struct{}),
-		BackupTimeFormat:        backupTimeFormat,
 	}
 
 	// Close the quit channel manually
@@ -1893,11 +1721,10 @@ func TestLoggerClose_AlreadyClosedChannel(t *testing.T) {
 
 func TestMillRunOnce_NoOp(t *testing.T) {
 	logger := &Logger{
-		MaxBackups:       0,
-		MaxAge:           0,
-		Compress:         false,
-		Filename:         filepath.Join(t.TempDir(), "noop.log"),
-		BackupTimeFormat: backupTimeFormat,
+		MaxBackups: 0,
+		MaxAge:     0,
+		Compress:   false,
+		Filename:   filepath.Join(t.TempDir(), "noop.log"),
 	}
 
 	// Should do nothing and return nil
@@ -1911,7 +1738,6 @@ func TestShouldTimeRotate_ZeroLastRotationTime(t *testing.T) {
 	logger := &Logger{
 		RotationInterval: time.Minute,
 		lastRotationTime: time.Time{}, // zero time
-		BackupTimeFormat: backupTimeFormat,
 	}
 
 	if logger.shouldTimeRotate() {
@@ -1922,10 +1748,9 @@ func TestShouldTimeRotate_ZeroLastRotationTime(t *testing.T) {
 func TestMillRunOnce_CompressEligible(t *testing.T) {
 	tmp := t.TempDir()
 	logger := &Logger{
-		Filename:         filepath.Join(tmp, "test.log"),
-		Compress:         true,
-		MaxBackups:       1,
-		BackupTimeFormat: backupTimeFormat,
+		Filename:   filepath.Join(tmp, "test.log"),
+		Compress:   true,
+		MaxBackups: 1,
 	}
 
 	// Create a non-compressed log file with a valid timestamp in name
@@ -1955,10 +1780,9 @@ func TestMillRunOnce_ExpiredFileSkipped(t *testing.T) {
 	base := filepath.Join(tmp, "logfile.log")
 
 	logger := &Logger{
-		Filename:         base,
-		MaxAge:           1,    // 1 day
-		Compress:         true, // trigger compression logic
-		BackupTimeFormat: backupTimeFormat,
+		Filename: base,
+		MaxAge:   1,    // 1 day
+		Compress: true, // trigger compression logic
 	}
 
 	// Manually choose a timestamp > 1 day old
@@ -1991,10 +1815,9 @@ func TestMillRun_TriggersMillRunOnce_Effect(t *testing.T) {
 	}
 
 	l := &Logger{
-		Filename:         logFile,
-		Compress:         true,
-		millCh:           make(chan bool),
-		BackupTimeFormat: backupTimeFormat,
+		Filename: logFile,
+		Compress: true,
+		millCh:   make(chan bool),
 	}
 
 	// Start millRun in background
@@ -2022,11 +1845,10 @@ func TestRotate_StartMillOnlyOnce_Observable(t *testing.T) {
 	tmp := t.TempDir()
 	base := filepath.Join(tmp, "logfile.log")
 	logger := &Logger{
-		Filename:         base,
-		MaxSize:          1,
-		Compress:         true,
-		millCh:           make(chan bool, 10), // Buffered so we can trigger multiple
-		BackupTimeFormat: backupTimeFormat,
+		Filename: base,
+		MaxSize:  1,
+		Compress: true,
+		millCh:   make(chan bool, 10), // Buffered so we can trigger multiple
 	}
 
 	// Create two valid backup files to be compressed
@@ -2071,9 +1893,8 @@ func TestScheduledMinuteRotationFails(t *testing.T) {
 	file := filepath.Join(tmp, "fail.log")
 
 	logger := &Logger{
-		Filename:         file,
-		RotateAtMinutes:  []int{0},
-		BackupTimeFormat: backupTimeFormat,
+		Filename:        file,
+		RotateAtMinutes: []int{0},
 	}
 	logger.processedRotateAtMinutes = []int{0}
 	logger.scheduledRotationQuitCh = make(chan struct{})
@@ -2102,7 +1923,6 @@ func TestRunScheduledRotations_CannotFindNextSlot(t *testing.T) {
 		Filename:                "test.log",
 		RotateAtMinutes:         []int{0},
 		scheduledRotationQuitCh: make(chan struct{}),
-		BackupTimeFormat:        backupTimeFormat,
 	}
 	logger.processedRotateAtMinutes = []int{0}
 	logger.scheduledRotationWg.Add(1)
@@ -2140,9 +1960,8 @@ func TestRunScheduledRotations_NoFutureSlotFound(t *testing.T) {
 	}
 
 	logger := &Logger{
-		Filename:         "mock.log",
-		RotateAtMinutes:  []int{0},
-		BackupTimeFormat: backupTimeFormat,
+		Filename:        "mock.log",
+		RotateAtMinutes: []int{0},
 	}
 	logger.processedRotateAtMinutes = []int{0}
 	logger.scheduledRotationQuitCh = make(chan struct{})
@@ -2166,9 +1985,8 @@ func TestScheduledRotation_TimerFiresAndRotates(t *testing.T) {
 	file := filepath.Join(tmpDir, "timerfire.log")
 
 	logger := &Logger{
-		Filename:         file,
-		RotateAtMinutes:  []int{1}, // Next minute after 'now'
-		BackupTimeFormat: backupTimeFormat,
+		Filename:        file,
+		RotateAtMinutes: []int{1}, // Next minute after 'now'
 	}
 	logger.processedRotateAtMinutes = []int{1}
 	logger.scheduledRotationQuitCh = make(chan struct{})
@@ -2194,10 +2012,9 @@ func TestMillRunOnce_RemoveFails(t *testing.T) {
 	defer func() { osRemove = origRemove }()
 
 	logger := &Logger{
-		Filename:         filepath.Join(tmp, "dummy.log"),
-		MaxBackups:       1,
-		Compress:         false,
-		BackupTimeFormat: backupTimeFormat,
+		Filename:   filepath.Join(tmp, "dummy.log"),
+		MaxBackups: 1,
+		Compress:   false,
 	}
 	err := logger.millRunOnce()
 	if err != nil {
@@ -2238,7 +2055,6 @@ func TestRunScheduledRotations_FallbackRetry(t *testing.T) {
 		RotateAtMinutes:          []int{0},
 		processedRotateAtMinutes: []int{0},
 		scheduledRotationQuitCh:  make(chan struct{}),
-		BackupTimeFormat:         backupTimeFormat,
 	}
 
 	logger.scheduledRotationWg.Add(1)
@@ -2258,7 +2074,6 @@ func TestRunScheduledRotations_TimerFires(t *testing.T) {
 		RotateAtMinutes:          []int{1},
 		processedRotateAtMinutes: []int{1},
 		scheduledRotationQuitCh:  make(chan struct{}),
-		BackupTimeFormat:         backupTimeFormat,
 	}
 
 	logger.lastRotationTime = time.Now().Add(-time.Hour)
@@ -2291,9 +2106,8 @@ func TestWrite_SizeRotateFails_4(t *testing.T) {
 	logPath := filepath.Join(tmp, "fail-size.log")
 
 	logger := &Logger{
-		Filename:         logPath,
-		MaxSize:          1, // 1 MB
-		BackupTimeFormat: backupTimeFormat,
+		Filename: logPath,
+		MaxSize:  1, // 1 MB
 	}
 
 	// Write almost max-size file manually
@@ -2339,7 +2153,6 @@ func TestWrite_IntervalRotationFails(t *testing.T) {
 		Filename:         logfile,
 		RotationInterval: time.Minute,
 		lastRotationTime: currentTime().Add(-2 * time.Minute),
-		BackupTimeFormat: backupTimeFormat,
 	}
 	defer logger.Close()
 
@@ -2365,7 +2178,6 @@ func TestRunScheduledRotations_NoFutureSlotRetry(t *testing.T) {
 		RotateAtMinutes:          []int{0}, // only candidate is "00"
 		processedRotateAtMinutes: []int{0},
 		scheduledRotationQuitCh:  make(chan struct{}),
-		BackupTimeFormat:         backupTimeFormat,
 	}
 
 	logger.scheduledRotationWg.Add(1)
@@ -2388,7 +2200,6 @@ func TestRunScheduledRotations_RotateFails(t *testing.T) {
 		RotateAtMinutes:          []int{0},
 		processedRotateAtMinutes: []int{0},
 		scheduledRotationQuitCh:  make(chan struct{}),
-		BackupTimeFormat:         backupTimeFormat,
 	}
 
 	logger.scheduledRotationWg.Add(1)
@@ -2418,7 +2229,6 @@ func TestRotate_ManualTriggersTimeRotation(t *testing.T) {
 		Filename:         filename,
 		RotationInterval: time.Minute,
 		lastRotationTime: time.Date(2025, 6, 5, 11, 58, 0, 0, time.UTC),
-		BackupTimeFormat: backupTimeFormat,
 	}
 	defer l.Close()
 
@@ -2479,7 +2289,6 @@ func TestRunScheduledRotations_FallbackOnRotateFailure(t *testing.T) {
 		RotateAtMinutes:          []int{0},
 		processedRotateAtMinutes: []int{0},
 		scheduledRotationQuitCh:  make(chan struct{}),
-		BackupTimeFormat:         backupTimeFormat,
 	}
 	logger.scheduledRotationWg.Add(1)
 
@@ -2493,9 +2302,8 @@ func TestRunScheduledRotations_FallbackOnRotateFailure(t *testing.T) {
 
 func TestLoggerClose_ClosesMillChannel(t *testing.T) {
 	logger := &Logger{
-		Filename:         "test-close-mill.log",
-		millCh:           make(chan bool, 1),
-		BackupTimeFormat: backupTimeFormat,
+		Filename: "test-close-mill.log",
+		millCh:   make(chan bool, 1),
 	}
 
 	// Set startMill to run millRun (to simulate actual usage)
@@ -2533,8 +2341,7 @@ func TestOpenNew_SetsLogStartTimeWhenFileMissing(t *testing.T) {
 	logfile := filepath.Join(dir, "missing.log")
 
 	logger := &Logger{
-		Filename:         logfile,
-		BackupTimeFormat: backupTimeFormat,
+		Filename: logfile,
 	}
 	defer logger.Close()
 
@@ -2545,5 +2352,134 @@ func TestOpenNew_SetsLogStartTimeWhenFileMissing(t *testing.T) {
 
 	if logger.logStartTime.IsZero() {
 		t.Fatal("expected logStartTime to be set, but it is zero")
+	}
+}
+
+func TestCountDigitsAfterDot(t *testing.T) {
+	tests := []struct {
+		layout   string
+		expected int
+	}{
+		{"2006-01-02 15:04:05", 0},           // no dot
+		{"2006-01-02 15:04:05.000", 3},       // exactly 3 digits
+		{"2006-01-02 15:04:05.000000", 6},    // 6 digits
+		{"2006-01-02 15:04:05.999999999", 9}, // 9 digits
+		{"2006-01-02 15:04:05.12345abc", 5},  // digits then letters
+		{"2006-01-02 15:04:05.", 0},          // dot but no digits
+		{".1234", 4},                         // string starts with dot + digits
+		{"prefix.987suffix", 3},              // digits then letters after dot
+		{"no_digits_after_dot.", 0},          // dot at end
+		{"no.dot.in.string", 0},              // dot but not fractional part
+	}
+
+	for _, test := range tests {
+		got := countDigitsAfterDot(test.layout)
+		if got != test.expected {
+			t.Errorf("countDigitsAfterDot(%q) = %d; want %d", test.layout, got, test.expected)
+		}
+	}
+}
+
+func TestSuffixTimeFormat(t *testing.T) {
+	tmp := t.TempDir()
+	logFile := filepath.Join(tmp, "invalid.log")
+
+	logger := &Logger{
+		Filename: logFile,
+	}
+
+	err := logger.ValidateBackupTimeFormat()
+	if err == nil {
+		t.Fatalf("empty timestamp layout determined as valid")
+	}
+
+	// parses correctly with err == nil, but parsed time.Time won't match the supplied time.Time
+
+	// invalid format
+
+	invalidFormat := "2006-15-05 23:20:53"
+	logger.BackupTimeFormat = invalidFormat
+	err = logger.ValidateBackupTimeFormat()
+	if err == nil {
+		t.Fatalf("invalid timestamp layout determined as valid")
+	}
+
+	// valid formats
+
+	validFormat := "20060102-15-04-05"
+	logger.BackupTimeFormat = validFormat
+	err = logger.ValidateBackupTimeFormat()
+	if err != nil {
+		t.Fatalf("valid timestamp layout determined as invalid")
+	}
+	validFormat = `2006-01-02-15-05-44.000`
+	logger.BackupTimeFormat = validFormat
+	err = logger.ValidateBackupTimeFormat()
+	if err != nil {
+		t.Errorf("valid timestamp layout determined as invalid")
+	}
+
+	validFormat2 := `2006-01-02-15-05-44.00000` // precision upto 5 digits after .
+	logger.BackupTimeFormat = validFormat2
+	err = logger.ValidateBackupTimeFormat()
+	if err != nil {
+		t.Errorf("valid timestamp2 layout determined as invalid")
+	}
+
+	validFormat3 := `2006-01-02-15-05-44.0000000` // precision upto 7 digits after .
+	logger.BackupTimeFormat = validFormat3
+	err = logger.ValidateBackupTimeFormat()
+	if err != nil {
+		t.Errorf("valid timestamp2 layout determined as invalid")
+	}
+
+	validFormat4 := `20060102-15-05` // precision upto 7 digits after .
+	logger.BackupTimeFormat = validFormat4
+	err = logger.ValidateBackupTimeFormat()
+	if err == nil {
+		t.Errorf("timestamp4 is invalid but determined as valid")
+	}
+}
+
+func TestTruncateFractional(t *testing.T) {
+	baseTime := time.Date(2025, 5, 23, 14, 30, 45, 987654321, time.UTC)
+
+	tests := []struct {
+		n         int
+		wantNanos int
+		wantErr   bool
+	}{
+		{n: 0, wantNanos: 0, wantErr: false},         // truncate to seconds
+		{n: 1, wantNanos: 900000000, wantErr: false}, // 1 digit fractional (100ms)
+		{n: 3, wantNanos: 987000000, wantErr: false}, // milliseconds
+		{n: 5, wantNanos: 987650000, wantErr: false}, // upto 5 digits
+		{n: 6, wantNanos: 987654000, wantErr: false}, // microseconds
+		{n: 7, wantNanos: 987654300, wantErr: false}, // upto 7 digits
+		{n: 9, wantNanos: 987654321, wantErr: false}, // nanoseconds, no truncation
+		{n: -1, wantNanos: 0, wantErr: true},         // invalid low
+		{n: 10, wantNanos: 0, wantErr: true},         // invalid high
+	}
+
+	for _, tt := range tests {
+		got, err := truncateFractional(baseTime, tt.n)
+
+		if (err != nil) != tt.wantErr {
+			t.Errorf("truncateFractional(_, %d) error = %v, wantErr %v", tt.n, err, tt.wantErr)
+			continue
+		}
+		if err != nil {
+			continue // don't check time if error expected
+		}
+
+		if got.Nanosecond() != tt.wantNanos {
+			t.Errorf("truncateFractional(_, %d) Nanosecond = %d; want %d", tt.n, got.Nanosecond(), tt.wantNanos)
+		}
+
+		// Verify that other time components are unchanged
+		if got.Year() != baseTime.Year() || got.Month() != baseTime.Month() ||
+			got.Day() != baseTime.Day() || got.Hour() != baseTime.Hour() ||
+			got.Minute() != baseTime.Minute() || got.Second() != baseTime.Second() {
+			t.Errorf("truncateFractional(_, %d) modified time components", tt.n)
+		}
 	}
 }


### PR DESCRIPTION
Added RotationFileSuffixTimeFormat field to Logger

default: 2006-01-02T15-04-05.000

It used for naming the rotated log files. If not set, then default value is used.

Added functions to count the precision of the layout passed and test the validity of the supplied layout. If the layout supplied is not valid then default is used

Issue: https://github.com/DeRuina/timberjack/issues/5