### PR TITLE
feat(rotation): add RotateAtMinutes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.2.0](https://github.com/DeRuina/timberjack/compare/v1.1.0...v1.2.0) (2025-05-27)
+
+
+### Features
+
+* release please script ([42d3575](https://github.com/DeRuina/timberjack/commit/42d35750d4f0f5cfac7c339ba9dcdee77527ab72))
+* release please script ([7514015](https://github.com/DeRuina/timberjack/commit/751401565635ff4eecbaffdf82e2333973cfe18a))
+
 ## [1.1.0] - 2025-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,18 +30,34 @@ component that manages log file writing and rotation. It plays well with any log
 
 ## Example
 
-To use timberjack with the standard library's `log` package:
+To use timberjack with the standard library's `log` package, including interval-based and scheduled minute-based rotation:
 
 ```go
-log.SetOutput(&timberjack.Logger{
-    Filename:         "/var/log/myapp/foo.log",
-    MaxSize:          500,            // megabytes
-    MaxBackups:       3,              // backups
-    MaxAge:           28,             // days
-    Compress:         true,           // default: false
-    LocalTime:        true,           // default: false
-    RotationInterval: time.Hour * 24, // rotate daily
-})
+import (
+	"log"
+	"time"
+	"github.com/DeRuina/timberjack"
+)
+
+func main() {
+	logger := &timberjack.Logger{
+		Filename:   "/var/log/myapp/foo.log", // Choose an appropriate path
+		MaxSize:    500,            // megabytes
+		MaxBackups: 3,              // backups
+		MaxAge:     28,             // days
+		Compress:   true,           // default: false
+		LocalTime:  true,           // default: false (use UTC)
+		RotationInterval: time.Hour * 24, // Rotate daily if no other rotation met
+		RotateAtMinutes: []int{0, 15, 30, 45}, // Also rotate at HH:00, HH:15, HH:30, HH:45
+	}
+	log.SetOutput(logger)
+	defer logger.Close() // Ensure logger is closed on application exit to stop goroutines
+
+	// Example log writes
+	log.Println("Application started")
+	// ... your application logic ...
+	log.Println("Application shutting down")
+}
 ```
 
 To trigger rotation on demand (e.g. in response to `SIGHUP`):
@@ -71,16 +87,17 @@ type Logger struct {
     LocalTime        bool          // Use local time in rotated filenames
     Compress         bool          // Compress rotated logs (gzip)
     RotationInterval time.Duration // Rotate after this duration (if > 0)
+    RotateAtMinutes []int          // Specific minutes within an hour (0-59) to trigger a rotation.
 }
 ```
 
 
 ## How Rotation Works
 
-1. **Size-Based**: If a write causes the log file to exceed `MaxSize`, it is rotated.
-2. **Time-Based**: If `RotationInterval` has elapsed since the log file was created, it is rotated.
-   The rotated filename reflects the **start time** of the log file (when it was first opened), not the time it was renamed.
-3. **Manual**: You can call `Logger.Rotate()` directly to force a rotation.
+1. **Size-Based**: If a write operation causes the current log file to exceed `MaxSize`, the file is rotated before the write. The backup filename will include `-size` as the reason.
+2. **Time-Based**: If `RotationInterval` is set (e.g., `time.Hour * 24` for daily rotation) and this duration has passed since the last rotation (of any type that updates the interval timer), the file is rotated upon the next write. The backup filename will include `-time` as the reason.
+3. **Scheduled Minute-Based**: If `RotateAtMinutes` is configured (e.g., `[]int{0, 30}` to rotate at `HH:00:00` and `HH:30:00`), a dedicated goroutine will trigger a rotation when the current time matches one of these minute marks. This rotation also uses `-time` as the reason in the backup filename.
+4. **Manual**: You can call `Logger.Rotate()` directly to force a rotation at any time. The reason in the backup filename will be `"-time"` if an interval rotation was also due, otherwise it defaults to `"-size"`.
 
 Rotated files are renamed using the pattern:
 
@@ -93,6 +110,7 @@ For example:
 ```
 /var/log/myapp/foo-2025-04-30T15-00-00.000-size.log
 /var/log/myapp/foo-2025-04-30T22-15-42.123-time.log
+/var/log/myapp/foo-2025-05-01T10:30:00.000-time.log.gz (if scheduled at HH:30 and compressed)
 ```
 
 ## Log Cleanup

--- a/chown_linux.go
+++ b/chown_linux.go
@@ -1,19 +1,25 @@
 package timberjack
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 )
 
-// osChown is a var so we can mock it out during tests.
-var osChown = os.Chown
+var osChown = os.Chown // Keep for testing
 
 func chown(name string, info os.FileInfo) error {
-	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
-	if err != nil {
-		return err
+	//// Should not be opening and truncating the file. It should just perform the osChown operation on the existing file name.
+	//// This is the primary cause of tests seeing 0 bytes.
+	// f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	// if err != nil {
+	// 	return err
+	// }
+	// f.Close()
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("failed to get syscall.Stat_t from FileInfo for %s", name)
 	}
-	f.Close()
-	stat := info.Sys().(*syscall.Stat_t)
 	return osChown(name, int(stat.Uid), int(stat.Gid))
 }


### PR DESCRIPTION
This feature provides clock-aligned rotations at the exact top of the hour (e.g., 14:00:00) or at specified minute marks (e.g., 14:30:00).

**RotateAtMinutes** is a new configuration parameter that specifies exact minute marks (0–59) at which to trigger a rotation. 
For example, ```[]int{0}``` triggers a rotation at the top of each hour, while ```[]int{0, 30}``` triggers at both the top and half-past. 
Rotations are aligned to the clock minute (second 0) and operate in addition to RotationInterval and MaxSize. 
If multiple rotation conditions coincide, the earliest one takes precedence.