### PR TITLE
Read permission for newly created file

### DIFF
--- a/timberjack.go
+++ b/timberjack.go
@@ -525,7 +525,7 @@ func (l *Logger) openNew(reasonForBackup string) error {
 	}
 
 	name := l.filename()
-	finalMode := os.FileMode(0600)
+	finalMode := os.FileMode(0640)
 	var oldInfo os.FileInfo
 
 	info, err := osStat(name)


### PR DESCRIPTION
quite useful if the scraper is not launched from root or from a user different from the user of the application