### PR TITLE
Add callback function into the Logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DeRuina/timberjack
+module github.com/traceforce/timberjack
 
 go 1.21
 


### PR DESCRIPTION
    This callback function will be invoked when file rotation happens.
    A list of existing log files will be provided to the callback instead
    of just the new one. The reason is that if the process need to restart
    at the middle of the last callback, the previous log files still have
    a chance to be processed by the callback. The callback needs to implement
    the mechanism to avoid processing the same log file twice (e.g. delete
    a log file after it is processed).