### PR TITLE
ci: Remove versioning strategy from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
-    versioning-strategy: "increase"
     groups:
       go-minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
Changed versioning strategy for Dependabot updates.