### PR TITLE
Make FileMode for newly created files configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ import (
 
 func main() {
 	logger := &timberjack.Logger{
-		Filename:         "/var/log/myapp/foo.log",   // Choose an appropriate path
-		MaxSize:          500,                        // megabytes
-		MaxBackups:       3,                          // backups
-		MaxAge:           28,                         // days
-    	Compression:      "gzip",                     // "none" | "gzip" | "zstd" (preferred over legacy Compress)
-		LocalTime:        true,                       // default: false (use UTC)
-		RotationInterval: 24 * time.Hour,             // Rotate daily if no other rotation met
-		RotateAtMinutes:  []int{0, 15, 30, 45},       // Also rotate at HH:00, HH:15, HH:30, HH:45
-		RotateAt:         []string{"00:00", "12:00"}, // Also rotate at 00:00 and 12:00 each day
-   		BackupTimeFormat: "2006-01-02-15-04-05",      // Rotated files will have format <logfilename>-2006-01-02-15-04-05-<reason>.log
-    	AppendTimeAfterExt:   true,                    // put timestamp after ".log" (foo.log-<timestamp>-<reason>)
-    
+        Filename:          "/var/log/myapp/foo.log",    // Choose an appropriate path
+        MaxSize:            500,                        // megabytes
+        MaxBackups:         3,                          // backups
+        MaxAge:             28,                         // days
+        Compression:        "gzip",                     // "none" | "gzip" | "zstd" (preferred over legacy Compress)
+        LocalTime:          true,                       // default: false (use UTC)
+        RotationInterval:   24 * time.Hour,             // Rotate daily if no other rotation met
+        RotateAtMinutes:    []int{0, 15, 30, 45},       // Also rotate at HH:00, HH:15, HH:30, HH:45
+        RotateAt:           []string{"00:00", "12:00"}, // Also rotate at 00:00 and 12:00 each day
+        BackupTimeFormat:   "2006-01-02-15-04-05",      // Rotated files will have format <logfilename>-2006-01-02-15-04-05-<reason>.log
+        AppendTimeAfterExt: true,                       // put timestamp after ".log" (foo.log-<timestamp>-<reason>)
+        FileMode:           0o644,                      // Custom permissions for newly created files. If unset or 0, defaults to 640.
 	}
 	log.SetOutput(logger)
 	defer logger.Close() // Ensure logger is closed on application exit to stop goroutines
@@ -124,6 +124,7 @@ type Logger struct {
     RotateAt          []string      // Specific daily times (HH:MM, 24-hour) to trigger rotation
     BackupTimeFormat  string        // Optional. If unset or invalid, defaults to 2006-01-02T15-04-05.000 (with fallback warning)
     AppendTimeAfterExt    bool      // if true, name backups like foo.log-<timestamp>-<reason> defaults to foo-<timestamp>-<reason>.log
+    FileMode          os.FileMode   // Use custom permissions for newly created files. If zero (unset or 0), defaults to 640.
 }
 ```
 


### PR DESCRIPTION
This allows users to set the desired file permissions as a Logger field. If unset (zero value), defaults to 640 as before.

Can be helpful e.g. in large companies where fiddling with file ownership is inappropriate. This way certain selected log files can be made world readable.

I also made two minor additional changes:

Octal numbers are rewritten to the recommended 0o-prefixed format (since Go 1.13).

The permissions for appending to an existing file were set to 644 before, which is useless and might confuse readers. I set it to 0, according to Go conventions.


## Type
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / chore
- [ ] Docs

## Details
Add field FileMode to Logger struct and honour if given. Otherwise use 0o640 as before.

## Tests
- [x] `go test ./...` passes locally
- [x] Added or updated tests
- [x] Verified behavior manually

## Backwards compatibility
- [x] No breaking changes
- [ ] Includes breaking changes (documented)