### PR TITLE
fix(compress): preserve source file mode on compressed backups under umask

### DIFF
--- a/timberjack.go
+++ b/timberjack.go
@@ -1223,6 +1223,14 @@ func (l *Logger) compressLogFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open destination compressed log file %s: %v", tmpDst, err)
 	}
+	// Apply the exact mode via chmod so the process umask cannot mask bits, mirroring openNew.
+	// Without this the compressed backup can end up with more restrictive permissions than the
+	// source log file whenever a non-zero umask is in effect.
+	if err := osChmod(tmpDst, srcInfo.Mode()); err != nil {
+		_ = dstFile.Close()
+		_ = os.Remove(tmpDst)
+		return fmt.Errorf("failed to set mode on compressed log file %s: %w", tmpDst, err)
+	}
 	// No `defer dstFile.Close()` here; explicit close ordering is critical.
 
 	var copyErr error // To capture error from io.Copy

--- a/timberjack_linux_test.go
+++ b/timberjack_linux_test.go
@@ -25,6 +25,42 @@ func TestRotate_OpenNewFails(t *testing.T) {
 	}
 }
 
+// TestCompressLogFilePreservesMode ensures that a compressed backup keeps the source log file's
+// permissions even when a non-zero umask is in effect. compressLogFile creates the destination
+// with srcInfo.Mode(), but without an explicit chmod the umask would mask bits — the same problem
+// that was fixed for newly created log files in openNew.
+func TestCompressLogFilePreservesMode(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Skipping test when running as root") // root bypasses permission bits
+	}
+
+	// A umask that would strip group/other bits from the source mode if no chmod is applied.
+	oldMask := syscall.Umask(0o077)
+	defer syscall.Umask(oldMask)
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "foo.log")
+	dst := src + compressSuffix
+
+	if err := os.WriteFile(src, []byte("compress me"), 0o666); err != nil {
+		t.Fatalf("failed to create source file: %v", err)
+	}
+	// Ensure the source really has mode 0o666 regardless of the umask set above.
+	if err := os.Chmod(src, 0o666); err != nil {
+		t.Fatalf("failed to chmod source file: %v", err)
+	}
+
+	l := &Logger{Filename: src}
+	l.resolveConfigLocked()
+
+	if err := l.compressLogFile(src, dst); err != nil {
+		t.Fatalf("compressLogFile failed: %v", err)
+	}
+
+	// The compressed file must keep the source mode, not have bits masked out by the umask.
+	hasPerm(dst, 0o666, t)
+}
+
 func TestCompressLogFile_CopyFails(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("Skipping test when running as root")


### PR DESCRIPTION
## Summary

`compressLogFile` creates the destination compressed file with `srcInfo.Mode()` as the requested permission, but never `chmod`s it afterwards:

```go
dstFile, err := l.resolvedOpenFile(tmpDst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, srcInfo.Mode())
```

When a non-zero **umask** is in effect, the kernel masks bits from the requested mode, so the compressed backup (`.gz` / `.zst`) ends up with **more restrictive permissions than the source log file**. For example, with a source mode of `0o666` and umask `0o077`, the compressed file is created as `0o600`.

This is the same class of issue that was fixed for newly created log files in `openNew` (#91 / #90), where an explicit `chmod` was added so the umask cannot mask bits. The compressed-file path was missed.

## Fix

Apply the same explicit `chmod` right after creating the temporary compressed file, mirroring `openNew`:

```go
if err := osChmod(tmpDst, srcInfo.Mode()); err != nil {
    _ = dstFile.Close()
    _ = os.Remove(tmpDst)
    return fmt.Errorf("failed to set mode on compressed log file %s: %w", tmpDst, err)
}
```

The temp file is later atomically renamed to the final destination, so the corrected mode is preserved.

## Testing

- Added `TestCompressLogFilePreservesMode` (linux): sets umask `0o077`, compresses a `0o666` source file, and asserts the compressed file keeps `0o666`. Confirmed it **fails without** this change (`got 0600`) and **passes with** it.
- `go vet ./...` clean; full suite passes with `-race`.
- Coverage: **91.4%** (≥ 85% requirement).

Commit follows Conventional Commits (`fix(compress): ...`).
