### PR TITLE
fix(format): detect fractional seconds correctly when validating BackupTimeFormat

### DIFF
--- a/timberjack.go
+++ b/timberjack.go
@@ -40,7 +40,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unicode"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -374,7 +373,7 @@ func (l *Logger) ValidateBackupTimeFormat() error {
 	// 2025-05-22 23:41:59.987654321 +0000 UTC
 	now := time.Date(2025, 5, 22, 23, 41, 59, 987_654_321, time.UTC)
 
-	layoutPrecision := countDigitsAfterDot(l.BackupTimeFormat)
+	layoutPrecision := fractionalSecondDigits(l.BackupTimeFormat)
 
 	now, err := truncateFractional(now, layoutPrecision)
 	if err != nil {
@@ -1155,28 +1154,41 @@ func (l *Logger) prefixAndExt() (prefix, ext string) {
 	return prefix, ext
 }
 
-// countDigitsAfterDot returns the number of consecutive digit characters
-// immediately following the first '.' in the input.
-// It skips all characters before the '.' and stops counting at the first non-digit
-// character after the '.'.
-
-// Example: `prefix.0012304123suffix` would return 10
-// Example: `prefix.0012304_middle_123_suffix` would return 7
-func countDigitsAfterDot(layout string) int {
-	for i, ch := range layout {
-		if ch == '.' {
-			count := 0
-			for _, c := range layout[i+1:] {
-				if unicode.IsDigit(c) {
-					count++
-				} else {
-					break
-				}
-			}
-			return count
+// fractionalSecondDigits returns the number of fractional-second digits in a Go
+// time layout. In a layout, fractional seconds are written as a '.' or ',' followed
+// by a run of '0's (fixed precision) or '9's (trailing zeros trimmed); any other '.'
+// (for example one used as a date or time separator) is a literal character and does
+// not denote fractional seconds.
+//
+// Examples:
+//
+//	"2006-01-02T15-04-05.000"  -> 3   (fractional seconds)
+//	"2006-01-02 15:04:05.999"  -> 3   (fractional seconds)
+//	"2006-01-02_15.04.05"      -> 0   ('.' used as a separator)
+//	"2006.01.02-15-04-05"      -> 0   ('.' used as a separator)
+func fractionalSecondDigits(layout string) int {
+	for i := 0; i < len(layout); i++ {
+		if layout[i] != '.' && layout[i] != ',' {
+			continue
 		}
+		j := i + 1
+		if j >= len(layout) || (layout[j] != '0' && layout[j] != '9') {
+			continue // not a fractional-second specifier
+		}
+		digit := layout[j]
+		n := 0
+		for j < len(layout) && layout[j] == digit {
+			n++
+			j++
+		}
+		// A genuine fractional run is a homogeneous run of '0's or '9's; if another
+		// digit follows immediately, this '.' is a literal separator (e.g. "15.04").
+		if j < len(layout) && layout[j] >= '0' && layout[j] <= '9' {
+			continue
+		}
+		return n
 	}
-	return 0 // no '.' found or no digits after dot
+	return 0
 }
 
 // truncateFractional truncates time t to n fractional digits of seconds.

--- a/timberjack_test.go
+++ b/timberjack_test.go
@@ -2386,27 +2386,30 @@ func TestOpenNew_SetsLogStartTimeWhenFileMissing(t *testing.T) {
 	}
 }
 
-func TestCountDigitsAfterDot(t *testing.T) {
+func TestFractionalSecondDigits(t *testing.T) {
 	tests := []struct {
 		layout   string
 		expected int
 	}{
-		{"2006-01-02 15:04:05", 0},           // no dot
-		{"2006-01-02 15:04:05.000", 3},       // exactly 3 digits
-		{"2006-01-02 15:04:05.000000", 6},    // 6 digits
-		{"2006-01-02 15:04:05.999999999", 9}, // 9 digits
-		{"2006-01-02 15:04:05.12345abc", 5},  // digits then letters
-		{"2006-01-02 15:04:05.", 0},          // dot but no digits
-		{".1234", 4},                         // string starts with dot + digits
-		{"prefix.987suffix", 3},              // digits then letters after dot
-		{"no_digits_after_dot.", 0},          // dot at end
-		{"no.dot.in.string", 0},              // dot but not fractional part
+		{"2006-01-02 15:04:05", 0},            // no dot
+		{"2006-01-02 15:04:05.000", 3},        // fractional seconds, 3 digits
+		{"2006-01-02 15:04:05.000000", 6},     // 6 digits
+		{"2006-01-02 15:04:05.999999999", 9},  // 9 digits (trailing-zero-trimmed)
+		{"2006-01-02 15:04:05,000", 3},        // comma is also a valid fractional separator
+		{"2006-01-02 15:04:05.12345abc", 0},   // '.' not followed by a 0/9 run -> separator, not fractional
+		{"2006-01-02 15:04:05.", 0},           // dot but no digits
+		{"2006-01-02_15.04.05", 0},            // '.' used as a time separator
+		{"2006.01.02-15-04-05", 0},            // '.' used as a date separator
+		{".1234", 0},                          // '.' followed by non 0/9 digit
+		{"prefix.987suffix", 0},               // not a fractional-second run
+		{"no_digits_after_dot.", 0},           // dot at end
+		{"no.dot.in.string", 0},               // dots followed by letters
 	}
 
 	for _, test := range tests {
-		got := countDigitsAfterDot(test.layout)
+		got := fractionalSecondDigits(test.layout)
 		if got != test.expected {
-			t.Errorf("countDigitsAfterDot(%q) = %d; want %d", test.layout, got, test.expected)
+			t.Errorf("fractionalSecondDigits(%q) = %d; want %d", test.layout, got, test.expected)
 		}
 	}
 }
@@ -2462,6 +2465,15 @@ func TestSuffixTimeFormat(t *testing.T) {
 	err = logger.ValidateBackupTimeFormat()
 	if err != nil {
 		t.Errorf("valid timestamp2 layout determined as invalid")
+	}
+
+	// Formats that use '.' as a separator (not as a fractional-second indicator) must be
+	// accepted; previously the precision was mis-detected and these were wrongly rejected.
+	for _, dotSeparated := range []string{`2006-01-02_15.04.05`, `2006.01.02-15-04-05`} {
+		logger.BackupTimeFormat = dotSeparated
+		if err = logger.ValidateBackupTimeFormat(); err != nil {
+			t.Errorf("format %q with '.' separator wrongly determined as invalid: %v", dotSeparated, err)
+		}
 	}
 
 	validFormat4 := `20060102-15-05` // precision upto 7 digits after .


### PR DESCRIPTION
## Summary

A custom `BackupTimeFormat` that uses `.` as a **separator** (rather than as a fractional-second indicator) is silently rejected by `ValidateBackupTimeFormat`, causing the logger to fall back to the default format.

`ValidateBackupTimeFormat` truncates a reference time to the precision returned by `countDigitsAfterDot`, which counts the digits after the **first `.` anywhere** in the layout. For a layout like `2006-01-02_15.04.05` (or `2006.01.02-15-04-05`), the `.` is a separator, not a fractional-second specifier — but `countDigitsAfterDot` reports a non-zero precision, so the reference time is truncated incorrectly, the format → parse round-trip comparison fails, and the format is reported invalid.

### Reproduction

```go
l := &timberjack.Logger{BackupTimeFormat: "2006-01-02_15.04.05"}
err := l.ValidateBackupTimeFormat()
// before: err != nil  -> format rejected, falls back to default
// after:  err == nil  -> format accepted
```

## Fix

Replace `countDigitsAfterDot` with `fractionalSecondDigits`, which only counts a `.` or `,` followed by a run of `0`s or `9`s — the way Go denotes fractional seconds in a layout. A `.` used as a separator (followed by other digits, e.g. `.04`) is no longer mistaken for fractional seconds.

The validation still correctly **rejects** lossy/ambiguous formats (e.g. `20060102-15-05`, which drops the minute), so existing behavior is preserved.

## Testing

- `TestFractionalSecondDigits` (renamed/updated from `TestCountDigitsAfterDot`) covers fractional formats, comma separators, and `.`-as-separator cases.
- `TestSuffixTimeFormat` now also asserts `2006-01-02_15.04.05` and `2006.01.02-15-04-05` are accepted (these failed before this change).
- `go vet ./...` clean; full suite passes with `-race`; coverage **91.9%** (≥ 85%).

Commit follows Conventional Commits (`fix(format): ...`).
